### PR TITLE
Add basic server with TypeScript, Express and Prisma

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+.env
+prisma/dev.db

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/app.ts",
+  "scripts": {
+    "dev": "prisma migrate deploy && ts-node-dev --respawn src/app.ts",
+    "build": "tsc",
+    "start": "node build/app.js",
+    "prisma": "prisma"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "@prisma/client": "^5.13.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node-dev": "^2.0.0",
+    "@types/node": "^18.0.0",
+    "@types/express": "^4.17.0",
+    "prisma": "^5.13.0"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,29 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Tag {
+  id   Int    @id @default(autoincrement())
+  name String @unique
+  players PlayerTag[]
+}
+
+model Player {
+  id   Int    @id @default(autoincrement())
+  name String
+  tags PlayerTag[]
+}
+
+model PlayerTag {
+  player   Player @relation(fields: [playerId], references: [id])
+  playerId Int
+  tag      Tag    @relation(fields: [tagId], references: [id])
+  tagId    Int
+
+  @@id([playerId, tagId])
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,84 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const app = express();
+
+app.use(express.json());
+
+// getTags
+app.get('/tags', async (_req, res) => {
+  const tags = await prisma.tag.findMany();
+  res.json(tags);
+});
+
+// addTag
+app.post('/tags', async (req, res) => {
+  const { name } = req.body;
+  if (!name) return res.status(400).json({ error: 'name required' });
+  try {
+    const tag = await prisma.tag.create({ data: { name } });
+    res.status(201).json(tag);
+  } catch (err) {
+    res.status(400).json({ error: 'could not create tag' });
+  }
+});
+
+// addPlayer
+app.post('/players', async (req, res) => {
+  const { name, tagIds } = req.body as { name: string; tagIds?: number[] };
+  if (!name) return res.status(400).json({ error: 'name required' });
+  try {
+    const player = await prisma.player.create({ data: { name } });
+    if (Array.isArray(tagIds)) {
+      for (const tagId of tagIds) {
+        await prisma.playerTag.create({ data: { playerId: player.id, tagId } });
+      }
+    }
+    const result = await prisma.player.findUnique({
+      where: { id: player.id },
+      include: { tags: { include: { tag: true } } },
+    });
+    res.status(201).json({
+      id: result!.id,
+      name: result!.name,
+      tags: result!.tags.map(pt => pt.tag),
+    });
+  } catch (err) {
+    res.status(400).json({ error: 'could not create player' });
+  }
+});
+
+// getPlayer
+app.get('/players/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const player = await prisma.player.findUnique({
+    where: { id },
+    include: { tags: { include: { tag: true } } },
+  });
+  if (!player) return res.sendStatus(404);
+  res.json({
+    id: player.id,
+    name: player.name,
+    tags: player.tags.map(pt => pt.tag),
+  });
+});
+
+// search players by name
+app.get('/players/search', async (req, res) => {
+  const q = (req.query.q as string) || '';
+  const players = await prisma.player.findMany({
+    where: { name: { contains: q, mode: 'insensitive' } },
+    include: { tags: { include: { tag: true } } },
+  });
+  res.json(
+    players.map(p => ({
+      id: p.id,
+      name: p.name,
+      tags: p.tags.map(pt => pt.tag),
+    }))
+  );
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server listening on port ${port}`));

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "build",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up `server` Node project with TypeScript strict mode
- add Express and Prisma dependencies
- define Prisma schema for `Player` and `Tag`
- implement basic API endpoints in `app.ts`
- provide dev script to run migrations and start the server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c3a79560832db86c16958e0ebfa0