### PR TITLE
Add Vite React client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+server/build
+client/dist
+client/node_modules

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Use the following commands from the repository root:
 # start the Node server
 npm --prefix server start
 
-# start the React client
-npm --prefix client start
+# start the React client (Vite dev server)
+npm --prefix client run dev
 
 # start the MCP server
 npm --prefix mcp start

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Real Madrid Roster</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "client",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+interface Player {
+  id: number
+  name: string
+}
+
+function App() {
+  const [players, setPlayers] = useState<Player[]>([])
+
+  useEffect(() => {
+    fetch('http://localhost:3000/players/search?q=')
+      .then(res => res.json())
+      .then(data => setPlayers(data))
+      .catch(err => console.error(err))
+  }, [])
+
+  return (
+    <div>
+      <h1>Real Madrid Roster</h1>
+      <ul>
+        {players.map(p => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default App

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 2rem;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold a Vite React app under `client/`
- use strict TypeScript options
- add a roster page fetching the players API
- ignore build and node_modules directories
- document new dev command in README

## Testing
- `npm --prefix server test` *(fails: Missing script)*
- `npm --prefix client test`
- `npm --prefix mcp test` *(fails: ENOENT no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca8afdf8832da90a2222dd6aacaa